### PR TITLE
Backward compatibility for R version < 4.0

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,7 @@
 # test whether a unit object has unit "null"
 is_null_unit <- function(u) {
   if (is.unit(u)) {
-    identical(grid::unitType(u), "null")  
+    identical(unit_type(u), "null")
   } else {
     FALSE
   }
@@ -10,7 +10,7 @@ is_null_unit <- function(u) {
 # test whether a unit object has unit "native"
 is_native_unit <- function(u) {
   if (is.unit(u)) {
-    identical(grid::unitType(u), "native")
+    identical(unit_type(u), "native")
   } else {
     FALSE
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,22 @@
+unit_type <- NULL
+.onLoad <- function(...) {
+  if (as.numeric(version$major) >= 4) {
+    unit_type <- getFromNamespace("unitType", "grid")
+  } else {
+    unit_type <- function(x) {
+      if (is.unit(x)) {
+        unit <- attr(x, "unit", exact = TRUE)
+        if (is.null(unit)) {
+          # Probably unit arithmetic, return *something* to check against
+          return(class(unit))
+        } else {
+          return(unit)
+        }
+      } else {
+        # This is R4.0 grid::unitType behavior
+        stop("Not a unit object")
+      }
+    }
+  }
+  utils::assignInMyNamespace("unit_type", unit_type)
+}


### PR DESCRIPTION
Should fix a backwards compatibility issue (#8) introduced in #7. 

This PR introduces a new function `unit_type()` that is created in the `.onLoad()` function and branches upon R version. 
If R < 4.0, it tries to grab the unit character attribute, else if R4.0+ it uses `grid::unitType()`.

The function in the R < 4.0 branch is **not** the equivalent to `grid::unitType()`: it doesn't resolve more complex units.
However, for the native and null unit checks in utils.R it should be *close enough* (I think).

I lightly tested the function examples in both R3.6.3 and R4.0.2 and they ran without problems on my machine.